### PR TITLE
Fix optional enum handling

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.2.2_preview / 2021-05-05
+
+- Add comprehensive handling for optional enumeration properties
+
 ## 0.2.1_preview / 2021-05-03
 
 - Add check for null SdsTypeProperty InterpolationMode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Python Library Sample
 
-**Version:** 0.2.1_preview
+**Version:** 0.2.2_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 

--- a/ocs_sample_library_preview/Asset/MetadataItem.py
+++ b/ocs_sample_library_preview/Asset/MetadataItem.py
@@ -164,7 +164,9 @@ class MetadataItem(object):
             result.Description = content['Description']
 
         if 'SdsTypeCode' in content:
-            result.SdsTypeCode = SdsTypeCodeType[content['SdsTypeCode']]
+            sds_type_code = content['SdsTypeCode']
+            if sds_type_code is not None:
+                result.SdsTypeCode = SdsTypeCodeType[sds_type_code]
 
         if 'Uom' in content:
             result.Uom = content['Uom']

--- a/ocs_sample_library_preview/Asset/Resolved/ResolvedProperty.py
+++ b/ocs_sample_library_preview/Asset/Resolved/ResolvedProperty.py
@@ -89,8 +89,8 @@ class ResolvedProperty(object):
 
     def toDictionary(self):
         return {'Id': self.Id, 'IsKey': self.IsKey, 'Uom': self.Uom, 'Order': self.Order,
-                'InterpolationMode': self.InterpolationMode,
-                'ExtrapolationMode': self.ExtrapolationMode,
+                'InterpolationMode': self.InterpolationMode.name,
+                'ExtrapolationMode': self.ExtrapolationMode.name,
                 'SdsType': self.SdsType.toDictionary(), 'Source': self.Source.toDictionary()}
 
     @staticmethod

--- a/ocs_sample_library_preview/DataView/DataView.py
+++ b/ocs_sample_library_preview/DataView/DataView.py
@@ -346,9 +346,13 @@ class DataView(object):
             result.DefaultInterval = content['DefaultInterval']
 
         if 'IndexTypeCode' in content:
-            result.IndexTypeCode = SdsTypeCode[content['IndexTypeCode']]
+            index_type_code = content['IndexTypeCode']
+            if index_type_code is not None:
+                result.IndexTypeCode = SdsTypeCode[index_type_code]
 
         if 'Shape' in content:
-            result.Shape = DataViewShape[content['Shape']]
+            shape = content['shape']
+            if shape is not None:
+                result.Shape = DataViewShape[shape]
 
         return result

--- a/ocs_sample_library_preview/DataView/Field.py
+++ b/ocs_sample_library_preview/DataView/Field.py
@@ -144,7 +144,9 @@ class Field(object):
             return result
 
         if 'Source' in content:
-            result.Source = FieldSource[content['Source']]
+            source = content['Source']
+            if source is not None:
+                result.Source = FieldSource[source]
 
         if 'Keys' in content:
             keys = content['Keys']

--- a/ocs_sample_library_preview/DataView/Query.py
+++ b/ocs_sample_library_preview/DataView/Query.py
@@ -84,23 +84,21 @@ class Query(object):
         return result
 
     @staticmethod
-    def fromJson(jsonObj):
-        return Query.fromDictionary(jsonObj)
-
-    @staticmethod
-    def fromDictionary(content):
-        query = Query()
+    def fromJson(content):
+        result = Query()
 
         if not content:
-            return query
+            return result
 
         if 'Id' in content:
-            query.Id = content['Id']
+            result.Id = content['Id']
 
         if 'Kind' in content:
-            query.Kind = DataItemResourceType[content['Kind']]
+            kind = content['Kind']
+            if kind is not None:
+                result.Kind = DataItemResourceType[kind]
 
         if 'Value' in content:
-            query.Value = content['Value']
+            result.Value = content['Value']
 
-        return query
+        return result

--- a/ocs_sample_library_preview/SDS/SdsStream.py
+++ b/ocs_sample_library_preview/SDS/SdsStream.py
@@ -12,7 +12,7 @@ class SdsStream(object):
     def __init__(self, id: str = None, type_id: str = None, name: str = None,
                  description: str = None, indexes: list[SdsStreamIndex] = None,
                  interpolation_mode: SdsInterpolationMode = None,
-                 extrapolationMode: SdsExtrapolationMode = None,
+                 extrapolation_mode: SdsExtrapolationMode = None,
                  property_overrides: list[SdsStreamPropertyOverride] = None):
         """
         :param id: required
@@ -33,7 +33,7 @@ class SdsStream(object):
         self.Description = description
         self.Indexes = indexes
         self.InterpolationMode = interpolation_mode
-        self.ExtrapolationMode = extrapolationMode
+        self.ExtrapolationMode = extrapolation_mode
         self.PropertyOverrides = property_overrides
 
     @property
@@ -192,10 +192,10 @@ class SdsStream(object):
                 result['Indexes'].append(value.toDictionary())
 
         if self.InterpolationMode is not None:
-            result['InterpolationMode'] = self.InterpolationMode
+            result['InterpolationMode'] = self.InterpolationMode.name
 
         if self.ExtrapolationMode is not None:
-            result['ExtrapolationMode'] = self.ExtrapolationMode
+            result['ExtrapolationMode'] = self.ExtrapolationMode.name
 
         if self.PropertyOverrides is not None:
             result['PropertyOverrides'] = []
@@ -232,10 +232,14 @@ class SdsStream(object):
                     result.Indexes.append(SdsStreamIndex.fromJson(value))
 
         if 'InterpolationMode' in content:
-            result.InterpolationMode = SdsInterpolationMode[content['InterpolationMode']]
+            interpolation_mode = content['InterpolationMode']
+            if interpolation_mode is not None:
+                result.InterpolationMode = SdsInterpolationMode[interpolation_mode]
 
         if 'ExtrapolationMode' in content:
-            result.ExtrapolationMode = SdsExtrapolationMode[content['ExtrapolationMode']]
+            extrapolation_mode = content['ExtrapolationMode']
+            if extrapolation_mode is not None:
+                result.ExtrapolationMode = SdsExtrapolationMode[extrapolation_mode]
 
         if 'PropertyOverrides' in content:
             property_overrides = content['PropertyOverrides']

--- a/ocs_sample_library_preview/SDS/SdsStreamPropertyOverride.py
+++ b/ocs_sample_library_preview/SDS/SdsStreamPropertyOverride.py
@@ -82,7 +82,7 @@ class SdsStreamPropertyOverride(object):
             result['Uom'] = self.Uom
 
         if self.InterpolationMode is not None:
-            result['InterpolationMode'] = self.InterpolationMode
+            result['InterpolationMode'] = self.InterpolationMode.name
 
         return result
 
@@ -100,6 +100,8 @@ class SdsStreamPropertyOverride(object):
             result.Uom = content['Uom']
 
         if 'InterpolationMode' in content:
-            result.InterpolationMode = SdsInterpolationMode[content['InterpolationMode']]
+            interpolation_mode = content['InterpolationMode']
+            if interpolation_mode is not None:
+                result.InterpolationMode = SdsInterpolationMode[interpolation_mode]
 
         return result

--- a/ocs_sample_library_preview/SDS/SdsStreamViewMapProperty.py
+++ b/ocs_sample_library_preview/SDS/SdsStreamViewMapProperty.py
@@ -116,7 +116,9 @@ class SdsStreamViewMapProperty(object):
             result.TargetId = content['TargetId']
 
         if 'Mode' in content:
-            result.Mode = SdsStreamViewMode(content['Mode'])
+            mode = content['Mode']
+            if mode is not None:
+                result.Mode = SdsStreamViewMode(mode)
 
         if 'SdsStreamViewMap' in content:
             from .SdsStreamViewMap import SdsStreamViewMap

--- a/ocs_sample_library_preview/SDS/SdsType.py
+++ b/ocs_sample_library_preview/SDS/SdsType.py
@@ -343,11 +343,15 @@ class SdsType(object):
                     result.DerivedTypes.append(SdsType.fromJson(value))
 
         if 'InterpolationMode' in content:
-            result.InterpolationMode = SdsInterpolationMode(
-                content['InterpolationMode'])
+            interpolation_mode = content['InterpolationMode']
+            if interpolation_mode is not None:
+                result.InterpolationMode = SdsInterpolationMode(
+                    interpolation_mode)
 
         if 'ExtrapolationMode' in content:
-            result.ExtrapolationMode = SdsExtrapolationMode(
-                content['ExtrapolationMode'])
+            extrapolation_mode = content['ExtrapolationMode']
+            if extrapolation_mode is not None:
+                result.ExtrapolationMode = SdsExtrapolationMode(
+                    extrapolation_mode)
 
         return result

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ocs_sample_library_preview",
-    version="0.2.1_preview",
+    version="0.2.2_preview",
     author="OSIsoft",
     license="Apache 2.0",
     author_email="dendres@osisoft.com",


### PR DESCRIPTION
#8 resolved this issue for `SdsTypeProperty.InterpolationMode`, but it is more pervasive across the library than I originally thought. This PR adds safer handling for all enumeration properties that are marked 'not required', since they could be returned as null/None.
This PR resolves an issue sample-ocs-waveform-python encountered with the new library that was not observed in the initial round of tests with the 0.2.0 library.