### PR TITLE
Add community id header

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.4.6_preview / 2021-11-12
+
+- Added support for community header when calling communities APIs
+
 ## 0.4.5_preview / 2021-10-21
 
 - Enhanced data view data form parameter support to allow for form=default

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Python Library Sample
 
-**Version:** 0.4.6_preview
+**Version:** 0.4.7_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Python Library Sample
 
-**Version:** 0.4.5_preview
+**Version:** 0.4.6_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 

--- a/ocs_sample_library_preview/BaseClient.py
+++ b/ocs_sample_library_preview/BaseClient.py
@@ -141,4 +141,5 @@ class BaseClient(object):
     def request(self, method: str, url: str, params=None, data=None, headers=None, **kwargs):
         if not headers:
             headers = self.sdsHeaders()
+
         return requests.request(method, url, params=params, data=data, headers=headers, **kwargs)

--- a/ocs_sample_library_preview/Streams.py
+++ b/ocs_sample_library_preview/Streams.py
@@ -1,6 +1,5 @@
 import json
 
-from requests.api import head
 from jsonpatch import JsonPatch
 from typing import Any
 
@@ -1114,9 +1113,7 @@ class Streams(PatchableSecurable, object):
         if count is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         return self.getSummariesUrl(self.__stream_path.format(
             tenant_id=self.__tenant,

--- a/ocs_sample_library_preview/Streams.py
+++ b/ocs_sample_library_preview/Streams.py
@@ -42,9 +42,7 @@ class Streams(PatchableSecurable, object):
         if stream_id is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get',
@@ -99,9 +97,7 @@ class Streams(PatchableSecurable, object):
         if query is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get',
@@ -286,9 +282,7 @@ class Streams(PatchableSecurable, object):
         if namespace_id is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get',
@@ -315,9 +309,7 @@ class Streams(PatchableSecurable, object):
         if namespace_id is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get',
@@ -379,9 +371,7 @@ class Streams(PatchableSecurable, object):
         if index is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__data_path.format(stream=url), params={'index': index}, headers=headers)
@@ -431,9 +421,7 @@ class Streams(PatchableSecurable, object):
         if url is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__first_path.format(stream=url), headers=headers)
@@ -483,9 +471,7 @@ class Streams(PatchableSecurable, object):
         if url is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__last_path.format(stream=url), headers=headers)
@@ -552,9 +538,7 @@ class Streams(PatchableSecurable, object):
         if end is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__data_path.format(stream=url),
@@ -640,9 +624,7 @@ class Streams(PatchableSecurable, object):
         if continuation_token is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__data_path.format(stream=url),
@@ -718,9 +700,7 @@ class Streams(PatchableSecurable, object):
         if end is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__data_path.format(stream=url), params={'startIndex': start, 'endIndex': end, 'form': form}, headers=headers)
@@ -822,9 +802,7 @@ class Streams(PatchableSecurable, object):
         if isinstance(boundary_type, SdsBoundaryType):
             boundary = boundary_type.value
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__transform_path.format(stream=url),
@@ -905,9 +883,7 @@ class Streams(PatchableSecurable, object):
         if count is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__transform_interpolated_path.format(stream=url),
@@ -979,9 +955,7 @@ class Streams(PatchableSecurable, object):
         for i in index:
             params.append(('index', i))
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get', self.__transform_interpolated_path.format(stream=url),
@@ -1086,9 +1060,7 @@ class Streams(PatchableSecurable, object):
         else:
             _path = self.__transform_sampled_path.format(stream=url)
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         response = self.__base_client.request(
             'get',
@@ -1179,9 +1151,7 @@ class Streams(PatchableSecurable, object):
         if count is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
 
         # if stream_view_id is not set, do not specify /transform/ route
         # and stream_view_id parameter
@@ -1409,9 +1379,7 @@ class Streams(PatchableSecurable, object):
         if join_mode is None:
             raise TypeError
 
-        headers = self.__base_client.sdsHeaders()
-        if community_id != '':
-            headers['community-id'] = community_id
+        headers = self.__getRequestHeaders(community_id=community_id)
             
         response = self.__base_client.request(
             'get',
@@ -1439,6 +1407,17 @@ class Streams(PatchableSecurable, object):
         return values
 
     # private methods
+
+    def __getRequestHeaders(self, community_id: str = ''):
+        """
+        returns headers to use for a request given a community id
+        :return: a collection of headers.
+        """
+        headers = self.__base_client.sdsHeaders()
+        if community_id != '':
+            headers['community-id'] = community_id
+
+        return headers
 
     def __setPathAndQueryTemplates(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='ocs_sample_library_preview',
-    version='0.4.5_preview',
+    version='0.4.6_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='ocs_sample_library_preview',
-    version='0.4.6_preview',
+    version='0.4.7_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',


### PR DESCRIPTION
This PR adds support for making communities API calls using the community Id header when querying streams or their data. By using the optional community id parameter you can provide the community Id that will be set as 'community-id' header.