### PR TITLE
Remove Stream Types from Shared Client

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Version History
 
-## 0.5.2_preview / 2022-01-12
+## 0.5.3_preview / 2022-01-12
 
 - Remove support for shared types
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.5.2_preview / 2022-01-12
+
+- Remove support for shared types
+
 ## 0.5.1_preview / 2021-12-18
 
 - Remove reliance on Asset v1-preview routes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Python Library Sample
 
-**Version:** 0.5.1_preview
+**Version:** 0.5.2_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Python Library Sample
 
-**Version:** 0.5.2_preview
+**Version:** 0.5.3_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 

--- a/ocs_sample_library_preview/SharedStreams.py
+++ b/ocs_sample_library_preview/SharedStreams.py
@@ -52,31 +52,6 @@ class SharedStreams(PatchableSecurable, object):
         result = SdsStream.fromJson(response.json())
         return result
 
-    def getStreamType(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str) -> SdsType:
-        """
-        Retrieves a stream type specified by 'stream_id' in a community specified by 'community_id' from the Sds Service
-        :param tenant_id: tenant to work against
-        :param namespace_id: namespace to work against
-        :param community_id: community to work against
-        :param stream_id: id of the stream
-        :return: the stream type as an SdsType
-        """
-        self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
-
-        response = self.__base_client.request(
-            'get',
-            self.__stream_type_path.format(
-                tenant_id=tenant_id,
-                namespace_id=namespace_id,
-                stream_id=self.__base_client.encode(stream_id)),
-            headers=headers)
-        self.__base_client.checkResponse(
-            response, f'Failed to get SdsStream type, {stream_id}.')
-
-        result = SdsType.fromJson(response.json())
-        return result
-
     def getStreams(self, tenant_id: str, namespace_id: str, community_id: str, query: str = '', skip: int = 0,
                    count: int = 100) -> list[SdsStream]:
         """
@@ -482,5 +457,4 @@ class SharedStreams(PatchableSecurable, object):
             '/Tenants/{tenant_id}/Namespaces/{namespace_id}'
         self.__streams_path = self.__base_path + '/Streams'
         self.__stream_path = self.__streams_path + '/{stream_id}'
-        self.__stream_type_path = self.__stream_path + '/Type'
         self.__bulk_join_path = self.__base_path + '/Bulk/Streams/Data/Joins'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='ocs_sample_library_preview',
-    version='0.5.1_preview',
+    version='0.5.2_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='ocs_sample_library_preview',
-    version='0.5.2_preview',
+    version='0.5.3_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',


### PR DESCRIPTION
Types are not supported in communities so this call should be removed.