### PR TITLE
added additional_header parameter to base client

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 0.5.4_preview / 2022-01-13
+
+- Implemented additional_headers parameter to base client's request function
+- Added verbosity and community id header wrapper functions
+
 ## 0.5.3_preview / 2022-01-12
 
 - Remove support for shared types

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Python Library Sample
 
-**Version:** 0.5.3_preview
+**Version:** 0.5.4_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 

--- a/ocs_sample_library_preview/BaseClient.py
+++ b/ocs_sample_library_preview/BaseClient.py
@@ -103,27 +103,6 @@ class BaseClient(object):
 
         return headers
 
-    def communityHeaders(self, community_id: str):
-        """
-        Gets the base headers needed for a Communities call
-        :param community_id: id of the community
-        :return:
-        """
-        headers = self.sdsHeaders()
-        headers['community-id'] = community_id
-
-        return headers
-
-    def sdsNonVerboseHeader(self):
-        """
-        Gets the base headers needed for an SDS call and adds accept-verbosity: non-verbose
-        :return:
-        """
-        headers = self.sdsHeaders()
-        headers['accept-verbosity'] = 'non-verbose'
-
-        return headers
-
     def checkResponse(self, response, main_message: str):
         if response.status_code < 200 or response.status_code >= 300:
             status = response.status_code
@@ -160,9 +139,17 @@ class BaseClient(object):
             message = main_message + errorToWrite
             raise SdsError(message)
 
-    def request(self, method: str, url: str, params=None, data=None, headers=None, **kwargs):
+    def request(self, method: str, url: str, params=None, data=None, headers=None, additional_headers=None, **kwargs):
+        
+        # Start with the necessary headers for SDS calls, such as authorization and content-type
         if not headers:
             headers = self.sdsHeaders()
+        
+        # Extend this with the additional headers provided that either suppliment or override the default values
+        # This allows additional headers to be added to the HTTP call without blocking the base header call
+        if additional_headers:
+            headers.update(additional_headers)
+
         return self.__session.request(method, url, params=params, data=data, headers=headers, **kwargs)
 
     def __del__(self):

--- a/ocs_sample_library_preview/BaseClient.py
+++ b/ocs_sample_library_preview/BaseClient.py
@@ -105,6 +105,31 @@ class BaseClient(object):
 
         return headers
 
+    def communityHeaders(self, community_id: str):
+        """
+        DEPRECATED - Use the additional_headers parameter on the BaseClient.request method 
+        and the getCommunityIdHeader function to add a community id header to a REST call\n\n
+        Gets the base headers needed for a Communities call
+        :param community_id: id of the community
+        :return:
+        """
+        headers = self.sdsHeaders()
+        headers['community-id'] = community_id
+
+        return headers
+
+    def sdsNonVerboseHeader(self):
+        """
+        DEPRECATED - Use the additional_headers parameter on the BaseClient.request method 
+        and the getVerbosityHeader function to add or override an accept-verbosity header to a REST call\n\n
+        Gets the base headers needed for an SDS call and adds accept-verbosity: non-verbose
+        :return:
+        """
+        headers = self.sdsHeaders()
+        headers['accept-verbosity'] = 'non-verbose'
+
+        return headers
+
     @staticmethod
     def getCommunityIdHeader(community_id: str) -> dict[str, str]:
         return { 'Community-id': community_id }
@@ -165,4 +190,3 @@ class BaseClient(object):
 
     def __del__(self):
         self.__session.close()
-

--- a/ocs_sample_library_preview/BaseClient.py
+++ b/ocs_sample_library_preview/BaseClient.py
@@ -97,11 +97,22 @@ class BaseClient(object):
         if (self.__auth_object is not None):
             headers['Authorization'] = 'Bearer %s' % self._getToken()
         if (self.__accept_verbosity):
-            headers['Accept-Verbosity'] = 'verbose'
+            # All possible routes should call the same verbosity header function to ensure case sensitivity
+            # accept-verbosity and Accept-Verbosity would not overwrite each other, leading to unpredicable response from OCS
+            headers.update(BaseClient.getVerbosityHeader(True))
         if self.__request_timeout is not None:
             headers['Request-Timeout'] = str(self.__request_timeout)
 
         return headers
+
+    @staticmethod
+    def getCommunityIdHeader(community_id: str) -> dict[str, str]:
+        return { 'Community-id': community_id }
+
+    @staticmethod
+    def getVerbosityHeader(verbose: bool) -> dict[str, str]:
+        verbosity_string = 'verbose' if verbose else 'non-verbose'
+        return { 'Accept-Verbosity': verbosity_string } 
 
     def checkResponse(self, response, main_message: str):
         if response.status_code < 200 or response.status_code >= 300:

--- a/ocs_sample_library_preview/DataViews.py
+++ b/ocs_sample_library_preview/DataViews.py
@@ -273,7 +273,9 @@ class DataViews(Securable, object):
             # if this parameter was not specified, use the base client's setting
             verbose = self.__base_client.AcceptVerbosity 
 
-        additional_headers = {'accept-verbosity': 'non-verbose'} if not verbose else None
+        # The base client does not add a verbosity header if the client is non-verbose, so for Data Views,
+        # this is the only condition that we need to handle here since 'non-verbose' is different from no header at all
+        additional_headers = BaseClient.getVerbosityHeader(False) if not verbose else None
 
         params = {
             'count': count,
@@ -352,7 +354,9 @@ class DataViews(Securable, object):
             # if this parameter was not specified, use the base client's setting
             verbose = self.__base_client.AcceptVerbosity 
 
-        additional_headers = {'accept-verbosity': 'non-verbose'} if not verbose else None
+        # The base client does not add a verbosity header if the client is non-verbose, so for Data Views,
+        # this is the only condition that we need to handle here since 'non-verbose' is different from no header at all
+        additional_headers = BaseClient.getVerbosityHeader(False) if not verbose else None
 
         params = {
             'count': count,

--- a/ocs_sample_library_preview/DataViews.py
+++ b/ocs_sample_library_preview/DataViews.py
@@ -273,7 +273,7 @@ class DataViews(Securable, object):
             # if this parameter was not specified, use the base client's setting
             verbose = self.__base_client.AcceptVerbosity 
 
-        headers = self.__base_client.sdsNonVerboseHeader() if not verbose else None
+        additional_headers = {'accept-verbosity': 'non-verbose'} if not verbose else None
 
         params = {
             'count': count,
@@ -294,7 +294,7 @@ class DataViews(Securable, object):
                     dataView_id=self.__base_client.encode(data_view_id),
                 ),
                 params=params,
-                headers=headers
+                additional_headers=additional_headers
             )
 
         self.__base_client.checkResponse(
@@ -352,7 +352,7 @@ class DataViews(Securable, object):
             # if this parameter was not specified, use the base client's setting
             verbose = self.__base_client.AcceptVerbosity 
 
-        headers = self.__base_client.sdsNonVerboseHeader() if not verbose else None
+        additional_headers = {'accept-verbosity': 'non-verbose'} if not verbose else None
 
         params = {
             'count': count,
@@ -372,7 +372,7 @@ class DataViews(Securable, object):
                     dataView_id=self.__base_client.encode(data_view_id),
                 ),
                 params=params,
-                headers=headers
+                additional_headers=additional_headers
             )
 
         self.__base_client.checkResponse(

--- a/ocs_sample_library_preview/SharedStreams.py
+++ b/ocs_sample_library_preview/SharedStreams.py
@@ -37,7 +37,7 @@ class SharedStreams(PatchableSecurable, object):
         :return:the Stream as SdsStream
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
         response = self.__base_client.request(
             'get',
@@ -65,7 +65,7 @@ class SharedStreams(PatchableSecurable, object):
         :return: array of SdsStreams
         """
         self.__validateParameters(tenant_id, namespace_id, community_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
         response = self.__base_client.request(
             'get',
@@ -102,7 +102,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, index)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url=self.__stream_path.format(
                 namespace_id=namespace_id,
                 tenant_id=tenant_id,
@@ -125,7 +125,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url=self.__stream_path.format(
                 tenant_id=tenant_id,
                 namespace_id=namespace_id,
@@ -149,7 +149,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
@@ -176,7 +176,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
@@ -206,7 +206,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, start, end, count)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
@@ -234,7 +234,7 @@ class SharedStreams(PatchableSecurable, object):
             defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, start, end)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
@@ -268,7 +268,7 @@ class SharedStreams(PatchableSecurable, object):
             is defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, start, skip, count, reversed, boundary_type)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
                         tenant_id=tenant_id,
                         namespace_id=namespace_id,
@@ -297,7 +297,7 @@ class SharedStreams(PatchableSecurable, object):
         defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, start, end, count)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
                 tenant_id=tenant_id if tenant_id != '' else tenant_id,
                 namespace_id=namespace_id,
@@ -322,7 +322,7 @@ class SharedStreams(PatchableSecurable, object):
         defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, index)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
                 tenant_id=tenant_id,
                 namespace_id=namespace_id,
@@ -351,7 +351,7 @@ class SharedStreams(PatchableSecurable, object):
             defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
@@ -382,7 +382,7 @@ class SharedStreams(PatchableSecurable, object):
             is defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
@@ -412,7 +412,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(namespace_id, stream_ids, start, end)
-        additional_headers = {'community-id': community_id}
+        additional_headers = BaseClient.getCommunityIdHeader(community_id)
             
         response = self.__base_client.request(
             'get',

--- a/ocs_sample_library_preview/SharedStreams.py
+++ b/ocs_sample_library_preview/SharedStreams.py
@@ -37,7 +37,7 @@ class SharedStreams(PatchableSecurable, object):
         :return:the Stream as SdsStream
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
 
         response = self.__base_client.request(
             'get',
@@ -45,7 +45,7 @@ class SharedStreams(PatchableSecurable, object):
                 tenant_id=tenant_id,
                 namespace_id=namespace_id,
                 stream_id=self.__base_client.encode(stream_id)),
-            headers=headers)
+            additional_headers=additional_headers)
         self.__base_client.checkResponse(
             response, f'Failed to get SdsStream, {stream_id}.')
 
@@ -62,7 +62,7 @@ class SharedStreams(PatchableSecurable, object):
         :return: the stream type as an SdsType
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
 
         response = self.__base_client.request(
             'get',
@@ -70,7 +70,7 @@ class SharedStreams(PatchableSecurable, object):
                 tenant_id=tenant_id,
                 namespace_id=namespace_id,
                 stream_id=self.__base_client.encode(stream_id)),
-            headers=headers)
+            additional_headers=additional_headers)
         self.__base_client.checkResponse(
             response, f'Failed to get SdsStream type, {stream_id}.')
 
@@ -90,7 +90,7 @@ class SharedStreams(PatchableSecurable, object):
         :return: array of SdsStreams
         """
         self.__validateParameters(tenant_id, namespace_id, community_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
 
         response = self.__base_client.request(
             'get',
@@ -98,7 +98,7 @@ class SharedStreams(PatchableSecurable, object):
                 tenant_id=tenant_id,
                 namespace_id=namespace_id),
             params={'query': query, 'skip': skip, 'count': count},
-            headers=headers)
+            additional_headers=additional_headers)
         self.__base_client.checkResponse(
             response, 'Failed to get all SdsStreams.')
         
@@ -127,13 +127,13 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, index)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url=self.__stream_path.format(
                 namespace_id=namespace_id,
                 tenant_id=tenant_id,
                 stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getValueUrl(url=url, index=index, value_class=value_class, headers=headers)
+        return self.__streams.getValueUrl(url=url, index=index, value_class=value_class, additional_headers=additional_headers)
 
     def getFirstValue(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, value_class: type = None) -> Any:
         """
@@ -150,14 +150,14 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url=self.__stream_path.format(
                 tenant_id=tenant_id,
                 namespace_id=namespace_id,
                 community_id=community_id,
                 stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getFirstValueUrl(url=url, value_class=value_class, headers=headers)
+        return self.__streams.getFirstValueUrl(url=url, value_class=value_class, additional_headers=additional_headers)
 
     def getLastValue(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, value_class: type = None) -> Any:
         """
@@ -174,13 +174,13 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
             stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getLastValueUrl(url=url, value_class=value_class, headers=headers)
+        return self.__streams.getLastValueUrl(url=url, value_class=value_class, additional_headers=additional_headers)
 
     def getWindowValues(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, start: str, end: str, value_class: type = None, filter: str = '') -> list[Any]:
         """
@@ -201,13 +201,13 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
             stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getWindowValuesUrl(url=url, value_class=value_class, start=start, end=end, filter=filter, headers=headers)
+        return self.__streams.getWindowValuesUrl(url=url, value_class=value_class, start=start, end=end, filter=filter, additional_headers=additional_headers)
 
     def getWindowValuesPaged(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, start: str,
                                 end: str, count: int, continuation_token: str = '', value_class: type = None, filter: str = '') -> SdsResultPage:
@@ -231,13 +231,13 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, start, end, count)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
             stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getWindowValuesPagedUrl(url=url, value_class=value_class, start=start, end=end, count=count, continuation_token=continuation_token, filter=filter, headers=headers)
+        return self.__streams.getWindowValuesPagedUrl(url=url, value_class=value_class, start=start, end=end, count=count, continuation_token=continuation_token, filter=filter, additional_headers=additional_headers)
 
     def getWindowValuesForm(self, tenant_id:str, namespace_id: str, community_id: str, stream_id: str, start: str,
                                end: str, form: str = '', value_class: type = None) -> list[Any]:
@@ -259,13 +259,13 @@ class SharedStreams(PatchableSecurable, object):
             defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, start, end)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
             stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getWindowValuesFormUrl(url=url, value_class=value_class, start=start, end=end, form=form, headers=headers)
+        return self.__streams.getWindowValuesFormUrl(url=url, value_class=value_class, start=start, end=end, form=form, additional_headers=additional_headers)
 
     def getRangeValues(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, start: str,
                           skip: int, count: int, reversed: bool, boundary_type: str,
@@ -293,14 +293,14 @@ class SharedStreams(PatchableSecurable, object):
             is defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, start, skip, count, reversed, boundary_type)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
                         tenant_id=tenant_id,
                         namespace_id=namespace_id,
                         stream_id=self.__base_client.encode(stream_id))
 
         return self.__streams.getRangeValuesUrl(url=url, value_class=value_class, start=start, skip=skip, count=count, 
-            reversed=reversed, boundary_type=boundary_type, filter=filter, stream_view_id=stream_view_id, headers=headers)
+            reversed=reversed, boundary_type=boundary_type, filter=filter, stream_view_id=stream_view_id, additional_headers=additional_headers)
 
     def getRangeValuesInterpolated(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str,
                                       start: str, end: str, count: int, value_class: type = None, filter: str = '') -> list[Any]:
@@ -322,13 +322,13 @@ class SharedStreams(PatchableSecurable, object):
         defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, start, end, count)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
                 tenant_id=tenant_id if tenant_id != '' else tenant_id,
                 namespace_id=namespace_id,
                 stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getRangeValuesInterpolatedUrl(url=url, value_class=value_class, start=start, end=end, count=count, filter=filter, headers=headers)
+        return self.__streams.getRangeValuesInterpolatedUrl(url=url, value_class=value_class, start=start, end=end, count=count, filter=filter, additional_headers=additional_headers)
 
     def getIndexCollectionValues(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str,
                                       index: list[str], value_class: type = None) -> list[Any]:
@@ -347,13 +347,13 @@ class SharedStreams(PatchableSecurable, object):
         defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id, index)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
                 tenant_id=tenant_id,
                 namespace_id=namespace_id,
                 stream_id=self.__base_client.encode(stream_id))
 
-        return self.__streams.getIndexCollectionValuesUrl(url=url, value_class=value_class, index=index, headers=headers)
+        return self.__streams.getIndexCollectionValuesUrl(url=url, value_class=value_class, index=index, additional_headers=additional_headers)
 
     def getSampledValues(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, start: str,
                             end: str, sample_by: str, intervals: str, value_class: type = None, filter: str = '', stream_view_id: str = '') -> list[Any]:
@@ -376,14 +376,14 @@ class SharedStreams(PatchableSecurable, object):
             defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
             stream_id=self.__base_client.encode(stream_id))
 
         return self.__streams.getSampledValuesUrl(url=url, value_class=value_class, start=start, end=end, sample_by=sample_by, 
-            intervals=intervals, filter=filter, stream_view_id=stream_view_id, headers=headers)
+            intervals=intervals, filter=filter, stream_view_id=stream_view_id, additional_headers=additional_headers)
 
     def getSummaries(self, tenant_id: str, namespace_id: str, community_id: str, stream_id: str, start: str,
                         end: str, count: int, stream_view_id: str = '', value_class: type = None, filter: str = '') -> list[Any]:
@@ -407,14 +407,14 @@ class SharedStreams(PatchableSecurable, object):
             is defined.  Otherwise it is a dynamic Python object
         """
         self.__validateParameters(tenant_id, namespace_id, community_id, stream_id)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
         url = self.__stream_path.format(
             tenant_id=tenant_id,
             namespace_id=namespace_id,
             stream_id=self.__base_client.encode(stream_id))
 
         return self.__streams.getSummariesUrl(url=url, value_class=value_class, start=start, end=end, 
-            count=count, stream_view_id=stream_view_id, filter=filter, headers=headers)
+            count=count, stream_view_id=stream_view_id, filter=filter, additional_headers=additional_headers)
 
     def getStreamsWindow(self, tenant_id: str, namespace_id: str, community_id: str, stream_ids: list[str],
                          start: str, end: str, join_mode: int = 1, value_class: type = None) -> list[Any]:
@@ -437,7 +437,7 @@ class SharedStreams(PatchableSecurable, object):
             Otherwise it is a dynamic Python object
         """
         self.__validateParameters(namespace_id, stream_ids, start, end)
-        headers = self.__base_client.communityHeaders(community_id=community_id)
+        additional_headers = {'community-id': community_id}
             
         response = self.__base_client.request(
             'get',
@@ -448,7 +448,7 @@ class SharedStreams(PatchableSecurable, object):
                     'startIndex': start,
                     'endIndex': end,
                     'joinMode': join_mode},
-            headers=headers)
+            additional_headers=additional_headers)
         self.__base_client.checkResponse(
             response, f'Failed to get bulk values for SdsStream: {stream_ids}.')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='ocs_sample_library_preview',
-    version='0.5.3_preview',
+    version='0.5.4_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',


### PR DESCRIPTION
~~[don't merge; this PR is just for comments]~~
[this PR can be merged when approved]

I added an 'additional_header' parameter to the base client request function so that one or more headers can be provided without blocking the request function's creation of the base headers dictionary. For the community header addition, and then the data view non-verbose header addition, each required the underlying sdsHeaders call to be made first, then the header added, then the new dictionary passed to the request function as is.

This new approach should be just as easy for adding headers such as these two, but should also facilitate the overriding of certain values. For example, any of the queries can now be changed to be verbose or non-verbose without affecting the base client's AcceptVerbosity setting. At the moment, only the data view stored/interpolated data calls implement this, but it will be trivial for anything else to do. 

It should also make it easy to extend multiple headers as necessary. For example, if you wanted to override the verbosity header and add a community id, the existing functions would be clumsy to use for that (call both wrapper functions, then merge the two returned dictionaries). But in this case, both headers can be passed as additional_headers, and the request function will add them to the sdsHeaders before executing the call.