### PR TITLE
ADH Branding

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.6.0_preview / 2022-01-27
+
+- Updated for AVEVA Data Hub and deprecated OCSClient in favor of new ADHClient
+
 ## 0.5.5_preview / 2022-01-14
 
 - Reinstated support for Python 3.7

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Aveva Data Hub Python Library Sample
 
-| :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub.  The samples also work on OSIsoft Cloud Services unless otherwise noted. |
+| :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 0.5.5_preview
+**Version:** 0.6.0_preview
 
-[![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
+[![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
 
 This sample library requires Python 3.7+. You can download Python [here](https://www.python.org/downloads/).
 - __NOTE__: The library previously required Python 3.9+ to take advantage of type annotations. To provide compatibility with environments that cannot upgrade Python to 3.9, `from __future__ import annotations` was added to each necessary file. [This provides backwards compatibility down to Python 3.7](https://docs.python.org/3/library/__future__.html).
 
 ## About the library
 
-The python ADH library is an introductory language-specific example of programming against Aveva Data Hub ([ADH](https://www.osisoft.com/Solutions/OSIsoft-Cloud-Services/)). It is intended as instructional samples only and are not for production use.
+The python ADH library is an introductory language-specific example of programming against Aveva Data Hub ([ADH](https://www.osisoft.com/Solutions/OSIsoft-Cloud-Services/)). It is intended as instructional samples only and are not for production use. *The samples also work on OSIsoft Cloud Services unless otherwise noted.*
 
 They can be obtained by running: `pip install ocs_sample_library_preview`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Aveva Data Hub Python Library Sample
 
+| :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub.  The samples also work on OSIsoft Cloud Services unless otherwise noted. |
+| -----------------------------------------------------------------------------------------------|  
+
 **Version:** 0.5.5_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2622&branchName=main)
@@ -9,9 +12,9 @@ This sample library requires Python 3.7+. You can download Python [here](https:/
 
 ## About the library
 
-The python ADH library is an introductory language-specific example of programming against Aveva Data Hub. It is intended as instructional samples only and are not for production use.
+The python ADH library is an introductory language-specific example of programming against Aveva Data Hub ([ADH](https://www.osisoft.com/Solutions/OSIsoft-Cloud-Services/)). It is intended as instructional samples only and are not for production use.
 
-They can be obtained by running: `pip install adh_sample_library_preview`
+They can be obtained by running: `pip install ocs_sample_library_preview`
 
 The library is not intended to show every endpoint and every option/parameter for endpoints it has. The library is known to be incomplete.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OSIsoft Cloud Services Python Library Sample
+# Aveva Data Hub Python Library Sample
 
 **Version:** 0.5.5_preview
 
@@ -9,9 +9,9 @@ This sample library requires Python 3.7+. You can download Python [here](https:/
 
 ## About the library
 
-The python OCS library is an introductory language-specific examples of programming against OSISoft Cloud Services ([OCS](https://www.osisoft.com/Solutions/OSIsoft-Cloud-Services/)). It is as instructional samples only and are not for production use.
+The python ADH library is an introductory language-specific example of programming against Aveva Data Hub. It is intended as instructional samples only and are not for production use.
 
-They can be obtained by running: `pip install ocs_sample_library_preview`
+They can be obtained by running: `pip install adh_sample_library_preview`
 
 The library is not intended to show every endpoint and every option/parameter for endpoints it has. The library is known to be incomplete.
 
@@ -23,8 +23,8 @@ Tests are done by testing the sample apps that use this.
 
 Developed using Python 3.9.5.
 
-[OSI Samples](https://github.com/osisoft/OSI-samples) are licensed under the Apache 2 license.
+[AVEVA Samples](https://github.com/osisoft/OSI-samples) are licensed under the Apache 2 license.
 
-For the main OCS sample libraries page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS/blob/main/docs/SAMPLE_LIBRARIES.md)  
-For the main OCS samples page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS)  
-For the main OSIsoft samples page [ReadMe](https://github.com/osisoft/OSI-Samples)
+For the main ADH sample libraries page [ReadMe](https://github.com/osisoft/OSI-Samples-ADH/blob/main/docs/SAMPLE_LIBRARIES.md)  
+For the main ADH samples page [ReadMe](https://github.com/osisoft/OSI-Samples-ADH)  
+For the main AVEVA samples page [ReadMe](https://github.com/osisoft/OSI-Samples)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ Developed using Python 3.9.5.
 
 [AVEVA Samples](https://github.com/osisoft/OSI-samples) are licensed under the Apache 2 license.
 
-For the main ADH sample libraries page [ReadMe](https://github.com/osisoft/OSI-Samples-ADH/blob/main/docs/SAMPLE_LIBRARIES.md)  
-For the main ADH samples page [ReadMe](https://github.com/osisoft/OSI-Samples-ADH)  
+For the main ADH sample libraries page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS/blob/main/docs/SAMPLE_LIBRARIES.md)  
+For the main ADH samples page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS)  
 For the main AVEVA samples page [ReadMe](https://github.com/osisoft/OSI-Samples)

--- a/ocs_sample_library_preview/ADHClient.py
+++ b/ocs_sample_library_preview/ADHClient.py
@@ -14,18 +14,18 @@ from .Topics import Topics
 from .Types import Types
 from .Users import Users
 
-class OCSClient:
+class ADHClient:
     """
-    A client that handles communication with OCS
+    A client that handles communication with ADH
     """
 
     def __init__(self, api_version: str, tenant: str, url: str, client_id: str,
                  client_secret: str = None, accept_verbosity: bool = False):
         """
-        Use this to help in communinication with OCS
+        Use this to help in communinication with ADH
         :param api_version: Version of the api you are communicating with
         :param tenant: Your tenant ID
-        :param url: The base URL for your OCS instance
+        :param url: The base URL for your ADH instance
         :param client_id: Your client ID
         :param client_secret: Your client Secret or Key
         :param accept_verbosity: Sets whether in value calls you get all values or just
@@ -51,14 +51,14 @@ class OCSClient:
     @property
     def uri(self) -> str:
         """
-        :return: The uri of this OCS client as a string
+        :return: The uri of this ADH client as a string
         """
         return self.__base_client.uri
 
     @property
     def tenant(self) -> str:
         """
-        :return: The tenant of this OCS client as a string
+        :return: The tenant of this ADH client as a string
         """
         return self.__base_client.tenant
 

--- a/ocs_sample_library_preview/Asset/Asset.py
+++ b/ocs_sample_library_preview/Asset/Asset.py
@@ -7,7 +7,7 @@ from .StreamReference import StreamReference
 
 
 class Asset(object):
-    """OCS Asset definition"""
+    """ADH Asset definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None,
                  asset_type_id: str = None, metadata: list[MetadataItem] = None,

--- a/ocs_sample_library_preview/Asset/AssetRule.py
+++ b/ocs_sample_library_preview/Asset/AssetRule.py
@@ -3,7 +3,7 @@ import json
 
 
 class AssetRule(object):
-    """OCS Asset Rule definition"""
+    """ADH Asset Rule definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None):
         """

--- a/ocs_sample_library_preview/Asset/AssetType.py
+++ b/ocs_sample_library_preview/Asset/AssetType.py
@@ -7,7 +7,7 @@ from .TypeReference import TypeReference
 
 
 class AssetType(object):
-    """OCS Asset Type definition"""
+    """ADH Asset Type definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None,
                  metadata: MetadataItem = None,

--- a/ocs_sample_library_preview/Asset/MetadataItem.py
+++ b/ocs_sample_library_preview/Asset/MetadataItem.py
@@ -5,7 +5,7 @@ from ..SDS.SdsTypeCode import SdsTypeCode as SdsTypeCodeType
 
 
 class MetadataItem(object):
-    """OCS Asset Metadata Item definition"""
+    """ADH Asset Metadata Item definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None,
                  sds_type_code: SdsTypeCodeType = None, uom: str = None, value: str = None):

--- a/ocs_sample_library_preview/Asset/Status/StatusConfiguration.py
+++ b/ocs_sample_library_preview/Asset/Status/StatusConfiguration.py
@@ -6,7 +6,7 @@ from .StatusMapping import StatusMapping
 
 
 class StatusConfiguration(object):
-    """OCS Asset Status Configuration definition"""
+    """ADH Asset Status Configuration definition"""
 
     def __init__(self, definition_type: StatusDefinitionType = None, definition: StatusMapping = None):
         """

--- a/ocs_sample_library_preview/Asset/Status/StatusMapping.py
+++ b/ocs_sample_library_preview/Asset/Status/StatusMapping.py
@@ -5,7 +5,7 @@ from .ValueStatusMapping import ValueStatusMapping
 
 
 class StatusMapping(object):
-    """OCS Asset Status Mapping definition"""
+    """ADH Asset Status Mapping definition"""
 
     def __init__(self, stream_reference_id: str = None, stream_property_id: str = None,
                  value_status_mappings: list[ValueStatusMapping] = None):

--- a/ocs_sample_library_preview/Asset/Status/ValueStatusMapping.py
+++ b/ocs_sample_library_preview/Asset/Status/ValueStatusMapping.py
@@ -6,7 +6,7 @@ from .StatusEnum import StatusEnum
 
 
 class ValueStatusMapping(object):
-    """OCS Asset Value Status Mapping definition"""
+    """ADH Asset Value Status Mapping definition"""
 
     def __init__(self, value: Any = None, status: StatusEnum = None, display_name: str = None):
         """

--- a/ocs_sample_library_preview/Asset/StreamReference.py
+++ b/ocs_sample_library_preview/Asset/StreamReference.py
@@ -3,7 +3,7 @@ import json
 
 
 class StreamReference(object):
-    """OCS Asset Stream Reference definition"""
+    """ADH Asset Stream Reference definition"""
 
     def __init__(self, id: str = None, name: str = None, stream_id: str = None,
                  description: str = None):

--- a/ocs_sample_library_preview/Asset/TypeReference.py
+++ b/ocs_sample_library_preview/Asset/TypeReference.py
@@ -3,7 +3,7 @@ import json
 
 
 class TypeReference(object):
-    """OCS Asset Type Type Reference definition"""
+    """ADH Asset Type Type Reference definition"""
 
     def __init__(self, stream_reference_id: str = None, stream_reference_name: str = None,
                  type_id: str = None, description: str = None):

--- a/ocs_sample_library_preview/AssetRules.py
+++ b/ocs_sample_library_preview/AssetRules.py
@@ -8,7 +8,7 @@ from .Securable import Securable
 
 class AssetRules(Securable, object):
     """
-    Client for interacting with OCS Asset Rules
+    Client for interacting with ADH Asset Rules
     This class does not represent the full functionality of the Asset Rules route and is included to allow management of security on the route
     """
 

--- a/ocs_sample_library_preview/AssetTypes.py
+++ b/ocs_sample_library_preview/AssetTypes.py
@@ -8,7 +8,7 @@ from .Securable import Securable
 
 class AssetTypes(Securable, object):
     """
-    Client for interacting with OCS Asset Types
+    Client for interacting with ADH Asset Types
     """
 
     def __init__(self, client: BaseClient):

--- a/ocs_sample_library_preview/Assets.py
+++ b/ocs_sample_library_preview/Assets.py
@@ -11,7 +11,7 @@ from .Securable import Securable
 
 class Assets(Securable, object):
     """
-    Client for interacting with OCS Assets
+    Client for interacting with ADH Assets
     """
 
     def __init__(self, client: BaseClient):

--- a/ocs_sample_library_preview/Communities.py
+++ b/ocs_sample_library_preview/Communities.py
@@ -9,7 +9,7 @@ from .Community.StreamSearchResult import StreamSearchResult
 
 class Communities(object):
     """
-    Client for interacting with OCS communities
+    Client for interacting with ADH communities
     """
 
     def __init__(self, client: BaseClient):

--- a/ocs_sample_library_preview/Community/Community.py
+++ b/ocs_sample_library_preview/Community/Community.py
@@ -5,7 +5,7 @@ from .CommunityTenant import CommunityTenant
 
 
 class Community(object):
-    """OCS community definition"""
+    """ADH community definition"""
 
     def __init__(self, id: str = None, name: str = None, alias: str = None, description: str = None,
                  tenants: list[CommunityTenant] = None, date_created: str = None,

--- a/ocs_sample_library_preview/Community/CommunityInput.py
+++ b/ocs_sample_library_preview/Community/CommunityInput.py
@@ -3,7 +3,7 @@ import json
 
 
 class CommunityInput(object):
-    """OCS community input definition"""
+    """ADH community input definition"""
 
     def __init__(self, name: str = None, description: str = None):
         self.Name = name

--- a/ocs_sample_library_preview/Community/CommunitySummaryInformation.py
+++ b/ocs_sample_library_preview/Community/CommunitySummaryInformation.py
@@ -3,7 +3,7 @@ import json
 
 
 class CommunitySummaryInformation(object):
-    """OCS community summary information definition"""
+    """ADH community summary information definition"""
 
     def __init__(self, total_streams: int = None, streams_contributed: int = None):
         self.TotalStreams = total_streams

--- a/ocs_sample_library_preview/Community/CommunityTenant.py
+++ b/ocs_sample_library_preview/Community/CommunityTenant.py
@@ -5,7 +5,7 @@ from .CommunityTenantStatus import CommunityTenantStatus
 
 
 class CommunityTenant(object):
-    """OCS community tenant definition"""
+    """ADH community tenant definition"""
 
     def __init__(self, id: str = None, name: str = None, status: CommunityTenantStatus = None,
                  is_owner: bool = None, user_count: int = None, client_count: int = None):

--- a/ocs_sample_library_preview/Community/StreamSearchResult.py
+++ b/ocs_sample_library_preview/Community/StreamSearchResult.py
@@ -3,7 +3,7 @@ import json
 
 
 class StreamSearchResult(object):
-    """OCS stream search result definition"""
+    """ADH stream search result definition"""
 
     def __init__(self, id: str = None, name: str = None, type_id: str = None,
                  description: str = None, self_link: str = None, tenant_id: str = None,

--- a/ocs_sample_library_preview/DataView/DataItem.py
+++ b/ocs_sample_library_preview/DataView/DataItem.py
@@ -7,7 +7,7 @@ from .MetadataValue import MetadataValue
 
 
 class DataItem(object):
-    """OCS Data Item definition"""
+    """ADH Data Item definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None,
                  type_id: str = None, resource_type: DataItemResourceType = None,

--- a/ocs_sample_library_preview/DataView/DataItemField.py
+++ b/ocs_sample_library_preview/DataView/DataItemField.py
@@ -5,7 +5,7 @@ from ..SDS.SdsTypeCode import SdsTypeCode
 
 
 class DataItemField(object):
-    """OCS Data Item Field definition"""
+    """ADH Data Item Field definition"""
 
     def __init__(self, id: str = None, name: str = None, type_code: SdsTypeCode = None,
                  uom: str = None, is_key: bool = None, stream_reference_name: str = None):

--- a/ocs_sample_library_preview/DataView/DataMapping.py
+++ b/ocs_sample_library_preview/DataView/DataMapping.py
@@ -7,7 +7,7 @@ from .SummaryDirection import SummaryDirection as SummaryDirectionType
 
 
 class DataMapping(object):
-    """OCS Data Mapping definition"""
+    """ADH Data Mapping definition"""
 
     def __init__(self, target_id: str = None, target_stream_reference_name: str = None,
                  target_field_key: str = None, type_code: SdsTypeCode = None, uom: str = None,

--- a/ocs_sample_library_preview/DataView/DataView.py
+++ b/ocs_sample_library_preview/DataView/DataView.py
@@ -9,7 +9,7 @@ from .Query import Query
 
 
 class DataView(object):
-    """OCS Data View definition"""
+    """ADH Data View definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None,
                  queries: list[Query] = None, index_field: Field = None,

--- a/ocs_sample_library_preview/DataView/Field.py
+++ b/ocs_sample_library_preview/DataView/Field.py
@@ -7,7 +7,7 @@ from .SummaryDirection import SummaryDirection as SummaryDirectionType
 
 
 class Field(object):
-    """OCS Field definition"""
+    """ADH Field definition"""
 
     def __init__(self, source: FieldSource = None, keys: list[str] = None,
                  stream_reference_names: list[str] = None, label: str = None,

--- a/ocs_sample_library_preview/DataView/FieldMapping.py
+++ b/ocs_sample_library_preview/DataView/FieldMapping.py
@@ -9,7 +9,7 @@ from .SummaryDirection import SummaryDirection as SummaryDirectionType
 
 
 class FieldMapping(object):
-    """OCS Field Mapping definition"""
+    """ADH Field Mapping definition"""
 
     def __init__(self, id: str = None, label: str = None, field_kind: FieldKindType = None,
                  data_mappings: list[DataMapping] = None, type_code: SdsTypeCode = None,

--- a/ocs_sample_library_preview/DataView/FieldSet.py
+++ b/ocs_sample_library_preview/DataView/FieldSet.py
@@ -5,7 +5,7 @@ from .Field import Field
 
 
 class FieldSet(object):
-    """OCS Field Set definition"""
+    """ADH Field Set definition"""
 
     def __init__(self, query_id: str = None, data_fields: list[Field] = None,
                  identifying_field: Field = None):

--- a/ocs_sample_library_preview/DataView/FieldSets.py
+++ b/ocs_sample_library_preview/DataView/FieldSets.py
@@ -5,7 +5,7 @@ from .FieldSet import FieldSet
 
 
 class ResolvedFieldSets(object):
-    """OCS Resolved Field Sets definition"""
+    """ADH Resolved Field Sets definition"""
 
     def __init__(self, time_of_resolution: str = None, items: list[FieldSet] = None):
         self.TimeOfResolution = time_of_resolution

--- a/ocs_sample_library_preview/DataView/MetadataValue.py
+++ b/ocs_sample_library_preview/DataView/MetadataValue.py
@@ -6,7 +6,7 @@ from ..SDS.SdsTypeCode import SdsTypeCode
 
 
 class MetadataValue(object):
-    """OCS Metadata Value definition"""
+    """ADH Metadata Value definition"""
 
     def __init__(self, name: str = None, value: Any = None, description: str = None,
                  type_code: SdsTypeCode = None, uom: str = None):

--- a/ocs_sample_library_preview/DataView/Query.py
+++ b/ocs_sample_library_preview/DataView/Query.py
@@ -4,7 +4,7 @@ from .DataItemResourceType import DataItemResourceType
 
 
 class Query(object):
-    """OCS Query definition"""
+    """ADH Query definition"""
 
     def __init__(self, id: str = None, kind: DataItemResourceType = None, value: str = None):
         """

--- a/ocs_sample_library_preview/DataView/ResolvedDataItems.py
+++ b/ocs_sample_library_preview/DataView/ResolvedDataItems.py
@@ -5,7 +5,7 @@ from .DataItem import DataItem
 
 
 class ResolvedDataItems(object):
-    """OCS Resolved Items definition"""
+    """ADH Resolved Items definition"""
 
     def __init__(self, time_of_resolution: str = None, items: list[DataItem] = None):
         self.TimeOfResolution = time_of_resolution

--- a/ocs_sample_library_preview/Namespaces.py
+++ b/ocs_sample_library_preview/Namespaces.py
@@ -8,7 +8,7 @@ from .Securable import Securable
 
 class Namespaces(Securable, object):
     """
-    Client for interacting with OCS Namespace
+    Client for interacting with ADH Namespace
     """
 
     def __init__(self, client: BaseClient):

--- a/ocs_sample_library_preview/OCSClient.py
+++ b/ocs_sample_library_preview/OCSClient.py
@@ -15,10 +15,15 @@ from .Types import Types
 from .Users import Users
 
 import warnings
+warnings.filterwarnings("default", category=DeprecationWarning, module=__name__)
 
 class OCSClient:
+    warnings.warn(
+        "OCSClient is deprecated as OSIsoft Cloud Services has now been migrated to AVEVA Data Hub, use ADHClient instead",
+        DeprecationWarning
+    )
     """
-    A client that handles communication with OCS
+    A client that handles communication with OCS. NOTE: OCSClient is deprecated as OSIsoft Cloud Services has now been migrated to AVEVA Data Hub, use ADHClient instead.
     """
 
     def __init__(self, api_version: str, tenant: str, url: str, client_id: str,
@@ -33,10 +38,6 @@ class OCSClient:
         :param accept_verbosity: Sets whether in value calls you get all values or just
             non-default values
         """
-        warnings.warn(
-            "OCSClient is deprecated as OSIsoft Cloud Services has now been migrated to AVEVA Data Hub, use ADHClient instead",
-            DeprecationWarning
-        )
 
         self.__base_client = BaseClient(api_version, tenant, url, client_id,
                                         client_secret, accept_verbosity)

--- a/ocs_sample_library_preview/OCSClient.py
+++ b/ocs_sample_library_preview/OCSClient.py
@@ -14,23 +14,30 @@ from .Topics import Topics
 from .Types import Types
 from .Users import Users
 
-class ADHClient:
+import warnings
+
+class OCSClient:
     """
-    A client that handles communication with AVEVA Data Hub
+    A client that handles communication with OCS
     """
 
     def __init__(self, api_version: str, tenant: str, url: str, client_id: str,
                  client_secret: str = None, accept_verbosity: bool = False):
         """
-        Use this to help in communinication with ADH
+        Use this to help in communinication with OCS
         :param api_version: Version of the api you are communicating with
         :param tenant: Your tenant ID
-        :param url: The base URL for your ADH instance
+        :param url: The base URL for your OCS instance
         :param client_id: Your client ID
         :param client_secret: Your client Secret or Key
         :param accept_verbosity: Sets whether in value calls you get all values or just
             non-default values
         """
+        warnings.warn(
+            "OCSClient is deprecated as OSIsoft Cloud Services has now been migrated to AVEVA Data Hub, use ADHClient instead",
+            DeprecationWarning
+        )
+
         self.__base_client = BaseClient(api_version, tenant, url, client_id,
                                         client_secret, accept_verbosity)
         self.__asset_rules = AssetRules(self.__base_client)
@@ -51,14 +58,14 @@ class ADHClient:
     @property
     def uri(self) -> str:
         """
-        :return: The uri of this ADH client as a string
+        :return: The uri of this OCS client as a string
         """
         return self.__base_client.uri
 
     @property
     def tenant(self) -> str:
         """
-        :return: The tenant of this ADH client as a string
+        :return: The tenant of this OCS client as a string
         """
         return self.__base_client.tenant
 

--- a/ocs_sample_library_preview/OMF/Subscription.py
+++ b/ocs_sample_library_preview/OMF/Subscription.py
@@ -3,7 +3,7 @@ import json
 
 
 class Subscription(object):
-    """OCS Subscription definition"""
+    """ADH Subscription definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None):
         """

--- a/ocs_sample_library_preview/OMF/Topic.py
+++ b/ocs_sample_library_preview/OMF/Topic.py
@@ -3,7 +3,7 @@ import json
 
 
 class Topic(object):
-    """OCS Topic definition"""
+    """ADH Topic definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None):
         """

--- a/ocs_sample_library_preview/Roles.py
+++ b/ocs_sample_library_preview/Roles.py
@@ -6,7 +6,7 @@ from .Security.Role import Role
 
 class Roles(object):
     """
-    Client for interacting with OCS Roles
+    Client for interacting with ADH Roles
     """
 
     TenantAdministratorRoleTypeId = '2dc742ab-39ea-4fc0-a39e-2bcb71c26a5f'

--- a/ocs_sample_library_preview/Security/AccessControlEntry.py
+++ b/ocs_sample_library_preview/Security/AccessControlEntry.py
@@ -8,7 +8,7 @@ from .Trustee import Trustee
 
 
 class AccessControlEntry(object):
-    """OCS access control entry definition"""
+    """ADH access control entry definition"""
 
     def __init__(self, trustee: 'Trustee' = None, access_type: 'AccessType' = None,
                  access_rights: CommonAccessRightsEnum = None):

--- a/ocs_sample_library_preview/Security/AccessControlList.py
+++ b/ocs_sample_library_preview/Security/AccessControlList.py
@@ -5,7 +5,7 @@ from .AccessControlEntry import AccessControlEntry
 
 
 class AccessControlList(object):
-    """OCS access control list definition"""
+    """ADH access control list definition"""
 
     def __init__(self, role_trustee_access_control_entries: list[AccessControlEntry] = None):
         self.RoleTrusteeAccessControlEntries = role_trustee_access_control_entries

--- a/ocs_sample_library_preview/Security/Owner.py
+++ b/ocs_sample_library_preview/Security/Owner.py
@@ -4,7 +4,7 @@ import json
 from .TrusteeType import TrusteeType
 
 class Owner(object):
-  """OCS owner definition"""
+  """ADH owner definition"""
 
   def __init__(self, type: TrusteeType = None, tenant_id: str = None, object_id: str = None):
       self.Type = type

--- a/ocs_sample_library_preview/Security/Role.py
+++ b/ocs_sample_library_preview/Security/Role.py
@@ -5,7 +5,7 @@ from .RoleScope import RoleScope
 
 
 class Role(object):
-    """OCS role definition"""
+    """ADH role definition"""
 
     def __init__(self, id: str = None, name: str = None, description: str = None,
                  role_scope: 'RoleScope' = None, tenant_id: str = None, community_id: str = None,

--- a/ocs_sample_library_preview/Security/Trustee.py
+++ b/ocs_sample_library_preview/Security/Trustee.py
@@ -5,7 +5,7 @@ from .TrusteeType import TrusteeType
 
 
 class Trustee(object):
-    """OCS trustee definition"""
+    """ADH trustee definition"""
 
     def __init__(self, type: TrusteeType = None, tenant_id: str = None, object_id: str = None):
         self.Type = type

--- a/ocs_sample_library_preview/Security/User.py
+++ b/ocs_sample_library_preview/Security/User.py
@@ -3,7 +3,7 @@ import json
 
 
 class User(object):
-    """OCS trustee definition"""
+    """ADH trustee definition"""
 
     def __init__(self, id: str = None, given_name: str = None, surname: str = None, name: str = None, email: str = None, contact_email: str = None, contact_given_name: str = None,
                  contact_surname: str = None, external_user_id: str = None, identity_provider_id: str = None,

--- a/ocs_sample_library_preview/Security/UserInvitation.py
+++ b/ocs_sample_library_preview/Security/UserInvitation.py
@@ -5,7 +5,7 @@ from .UserInvitationState import UserInvitationState
 
 
 class UserInvitation(object):
-    """OCS trustee definition"""
+    """ADH trustee definition"""
 
     def __init__(self, id: str = None, expires_date_time: str = None, issued: str = None, expires: str = None, accepted: str = None,
                  state: UserInvitationState = None, send_invitation: bool = None, identity_provider_id: str = None, tenant_id: str = None, user_id: str = None):

--- a/ocs_sample_library_preview/StreamViews.py
+++ b/ocs_sample_library_preview/StreamViews.py
@@ -106,7 +106,7 @@ class StreamViews(PatchableSecurable, object):
         Tells Sds Service to create a streamView based on a local
             SdsStreamView object
         :param namespace_id: namespace to work against
-        :param stream_view: Streamview object to create in OCS
+        :param stream_view: Streamview object to create in ADH
         :return: created Streamview as SdsStreamview
         """
         if namespace_id is None:
@@ -131,7 +131,7 @@ class StreamViews(PatchableSecurable, object):
         """
         Tells Sds Service to create a streamView based on a local SdsStreamView object
         :param namespace_id: namespace to work against
-        :param stream_view: Streamview object to create or update in OCS
+        :param stream_view: Streamview object to create or update in ADH
         :return: created Streamview as SdsStream
         """
         if namespace_id is None:

--- a/ocs_sample_library_preview/Streams.py
+++ b/ocs_sample_library_preview/Streams.py
@@ -1136,7 +1136,7 @@ class Streams(PatchableSecurable, object):
         into the stream specified by 'stream_id'
         :param namespace_id: id of namespace to work against
         :param stream_id: id of the stream to get data into
-        :param values: values to sends into OCS.
+        :param values: values to sends into ADH.
             Can be string of json array of values.
             Can be an array of values of a type that has toJson defined.
         :return:
@@ -1172,7 +1172,7 @@ class Streams(PatchableSecurable, object):
         Tells Sds Service to update values defined by the SdsValue list, 'values'
         :param namespace_id: id of namespace to work against
         :param stream_id: id of the stream to get data updated
-        :param values: values to update in OCS.
+        :param values: values to update in ADH.
         Can be string of json array of values.
         Can be an array of values of a type that has toJson defined.
         :return:
@@ -1208,7 +1208,7 @@ class Streams(PatchableSecurable, object):
         Tells Sds Service to replace the values defined by the list 'values'
         :param namespace_id: id of namespace to work against
         :param stream_id: id of the stream to get data replaced
-        :param values: values to replace in OCS.
+        :param values: values to replace in ADH.
             Can be string of json array of values.
             Can be an array of values of a type that has toJson defined.
         :return:

--- a/ocs_sample_library_preview/Subscriptions.py
+++ b/ocs_sample_library_preview/Subscriptions.py
@@ -8,7 +8,7 @@ from .Securable import Securable
 
 class Subscriptions(Securable, object):
     """
-    Client for interacting with OCS Subscriptions
+    Client for interacting with ADH Subscriptions
     This class does not represent the full functionality of the Subscriptions route and is included to allow management of security on the route
     """
 

--- a/ocs_sample_library_preview/Tenant/Namespace.py
+++ b/ocs_sample_library_preview/Tenant/Namespace.py
@@ -7,7 +7,7 @@ from .NamespaceProvisioningState import NamespaceProvisioningState
 
 
 class Namespace(object):
-    """OCS namespace definition"""
+    """ADH namespace definition"""
 
     def __init__(self, id: str = None, region: str = None, namespace_self: str = None, description: str = None, state: NamespaceProvisioningState = None,
                  owner: Trustee = None, access_control: AccessControlList = None, region_id: str = None, instance_id: str = None):

--- a/ocs_sample_library_preview/Topics.py
+++ b/ocs_sample_library_preview/Topics.py
@@ -8,7 +8,7 @@ from .Securable import Securable
 
 class Topics(Securable, object):
     """
-    Client for interacting with OCS Topics
+    Client for interacting with ADH Topics
     This class does not represent the full functionality of the Topics route and is included to allow management of security on the route
     """
 

--- a/ocs_sample_library_preview/__init__.py
+++ b/ocs_sample_library_preview/__init__.py
@@ -1,5 +1,6 @@
 from .BaseClient import BaseClient
 from .ADHClient import ADHClient
+from .OCSClient import OCSClient
 from .EDSClient import EDSClient
 from .AssetRules import AssetRules
 from .Assets import Assets

--- a/ocs_sample_library_preview/__init__.py
+++ b/ocs_sample_library_preview/__init__.py
@@ -1,5 +1,5 @@
 from .BaseClient import BaseClient
-from .OCSClient import OCSClient
+from .ADHClient import ADHClient
 from .EDSClient import EDSClient
 from .AssetRules import AssetRules
 from .Assets import Assets

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='ocs_sample_library_preview',
-    version='0.5.5_preview',
+    version='0.6.0_preview',
     author='AVEVA',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     url='https://github.com/osisoft/sample-ocs-sample_libraries-python',
     packages=setuptools.find_packages(),
     install_requires=[
-        'requests>=2.26.0',
+        'requests>=2.27.1',
         'python-dateutil>=2.8.2',
         'jsonpatch>=1.32'
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name='adh_sample_library_preview',
+    name='ocs_sample_library_preview',
     version='0.5.5_preview',
     author='AVEVA',
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name='ocs_sample_library_preview',
+    name='adh_sample_library_preview',
     version='0.5.5_preview',
-    author='OSIsoft',
+    author='AVEVA',
     license='Apache 2.0',
     author_email='dendres@osisoft.com',
-    description='A preview of an OCS (OSIsoft Cloud Services) client library',
+    description='A preview of an ADH (Aveva Data Hub) client library',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/osisoft/sample-ocs-sample_libraries-python',


### PR DESCRIPTION
This PR changes cosmetic branding from OSIsoft and OCS to AVEVA and ADH.

## What's Included
Following has been updated
* README resources
* Company name
* OCS mentions
* Link titles
* Cloud portal links
* Sample library ref
 
The following is not included in this update
* History files
* GitHub links
* Build references
* Currently dead links such as ocs-docs (Will investigate best practice here) and OCS Overview pages (There is an option for this here https://www.aveva.com/content/dam/aveva/documents/datasheets/Datasheet_AVEVA_DataHubAnnouncementand_FAQ_10-21.pdf
* Copyright and License files


Let me know if anything is missing or incorrect above.


## Renaming
For the renaming of this library I have thought of some options:
* Leave renaming the library out for now until we can fully migrate all resources and links
* Follow instructions outlined here https://github.com/simonw/pypi-rename
    Basic thought is to: 
    * Create a renamed version of the package
    * Publish it to PyPI under the new name
    * Now create a final release under the old name which does the following:
    * Tells users about the name change
    * Depends on the new name, so anyone who runs pip install oldname will get the new name as a dependency
* Publish adh version and keep both, then handle the migration in dependency update

I think the PyPi instructions makes sense but let me know what you think there.

## History and Version Bump
These will be updated once we decide how to move forward with the renaming
